### PR TITLE
Feature/env variable support

### DIFF
--- a/src/api/AbstractApiClient.php
+++ b/src/api/AbstractApiClient.php
@@ -22,12 +22,7 @@ abstract class AbstractApiClient extends \GuzzleHttp\Client
 {
     public function __construct(array $config = [])
     {
-        $settings = HOMMSocialFeed::$plugin->getSettings();
-
-        if (!App::parseEnv($settings->feedUrl)) {
-            $config['base_uri'] = App::parseEnv($settings->socialFeedBaseUrl);
-        }
-
+        $config['base_uri'] = App::parseEnv(HOMMSocialFeed::$plugin->getSettings()->socialFeedBaseUrl);
         parent::__construct($config);
     }
 
@@ -38,14 +33,7 @@ abstract class AbstractApiClient extends \GuzzleHttp\Client
 
     protected function getApiPath(): string
     {
-        $settings = HOMMSocialFeed::$plugin->getSettings();
-
-        $feedUrl = App::parseEnv($settings->feedUrl);
-        if ($feedUrl) {
-            return $feedUrl;
-        }
-
-        $apiPath = App::parseEnv($settings->apiPath);
+        $apiPath = App::parseEnv(HOMMSocialFeed::$plugin->getSettings()->apiPath);
 
         if (!$apiPath) {
             throw new \Exception('The API path is not provided. Please check your plugin settings.');

--- a/src/api/AbstractApiClient.php
+++ b/src/api/AbstractApiClient.php
@@ -10,6 +10,7 @@
 
 namespace homm\hommsocialfeed\api;
 
+use craft\helpers\App;
 use homm\hommsocialfeed\HOMMSocialFeed;
 
 /**
@@ -21,7 +22,7 @@ abstract class AbstractApiClient extends \GuzzleHttp\Client
 {
     public function __construct(array $config = [])
     {
-        $config['base_uri'] = HOMMSocialFeed::$plugin->getSettings()->socialFeedBaseUrl;
+        $config['base_uri'] = App::parseEnv(HOMMSocialFeed::$plugin->getSettings()->socialFeedBaseUrl);
         parent::__construct($config);
     }
 
@@ -32,7 +33,7 @@ abstract class AbstractApiClient extends \GuzzleHttp\Client
 
     protected function getApiPath(): string
     {
-        $apiPath = HOMMSocialFeed::$plugin->getSettings()->apiPath;
+        $apiPath = App::parseEnv(HOMMSocialFeed::$plugin->getSettings()->apiPath);
 
         if (!$apiPath) {
             throw new \Exception('The API path is not provided. Please check your plugin settings.');

--- a/src/api/AbstractApiClient.php
+++ b/src/api/AbstractApiClient.php
@@ -22,7 +22,12 @@ abstract class AbstractApiClient extends \GuzzleHttp\Client
 {
     public function __construct(array $config = [])
     {
-        $config['base_uri'] = App::parseEnv(HOMMSocialFeed::$plugin->getSettings()->socialFeedBaseUrl);
+        $settings = HOMMSocialFeed::$plugin->getSettings();
+
+        if (!App::parseEnv($settings->feedUrl)) {
+            $config['base_uri'] = App::parseEnv($settings->socialFeedBaseUrl);
+        }
+
         parent::__construct($config);
     }
 
@@ -33,7 +38,14 @@ abstract class AbstractApiClient extends \GuzzleHttp\Client
 
     protected function getApiPath(): string
     {
-        $apiPath = App::parseEnv(HOMMSocialFeed::$plugin->getSettings()->apiPath);
+        $settings = HOMMSocialFeed::$plugin->getSettings();
+
+        $feedUrl = App::parseEnv($settings->feedUrl);
+        if ($feedUrl) {
+            return $feedUrl;
+        }
+
+        $apiPath = App::parseEnv($settings->apiPath);
 
         if (!$apiPath) {
             throw new \Exception('The API path is not provided. Please check your plugin settings.');

--- a/src/config.php
+++ b/src/config.php
@@ -23,5 +23,20 @@
  */
 
 return [
-    // code...
+    // Social Feed base URL. Supports environment variables (e.g. '$JUICER_BASE_URL').
+    // 'socialFeedBaseUrl' => 'https://www.juicer.io',
+
+    // API path for fetching feeds. Supports environment variables (e.g. '$JUICER_API_PATH').
+    // 'apiPath' => '/api/feeds/your-feed-name',
+
+    // Number of posts to fetch per request.
+    // 'numberOfFeeds' => 15,
+
+    // Available colors for tagging feed items ('handle' => CSS color value).
+    // Note: only the handle is stored per feed item.
+    // 'colors' => [
+    //     'muted'     => '#F0F0F1',
+    //     'highlight' => '#DD1460',
+    //     'dark'      => '#313131',
+    // ],
 ];

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -23,14 +23,7 @@ class Settings extends Model
     // =========================================================================
 
     /**
-     * @var string|null Complete feed URL (e.g. 'https://www.juicer.io/api/feeds/my-feed').
-     *                  When set, takes precedence over socialFeedBaseUrl + apiPath.
-     *                  Supports environment variables (e.g. '$JUICER_FEED').
-     */
-    public $feedUrl;
-
-    /**
-     * @var string Social Feed base url. Supports environment variables (e.g. '$JUICER_BASE_URL').
+     * @var string Social Feed base URL. Supports environment variables (e.g. '$JUICER_BASE_URL').
      */
     public $socialFeedBaseUrl = 'https://www.juicer.io';
 
@@ -47,7 +40,7 @@ class Settings extends Model
     ];
 
     /**
-     * @var string '/api/feeds/[company-name]'. Supports environment variables (e.g. '$JUICER_API_PATH').
+     * @var string API path for fetching feeds (e.g. '/api/feeds/company-name'). Supports environment variables (e.g. '$JUICER_API_PATH').
      */
     public $apiPath;
 
@@ -65,8 +58,7 @@ class Settings extends Model
     public function rules(): array
     {
         return [
-            ['numberOfFeeds', 'required'],
-            [['apiPath'], 'required', 'when' => fn($model) => !$model->feedUrl],
+            [['apiPath', 'numberOfFeeds'], 'required'],
         ];
     }
 }

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -23,7 +23,7 @@ class Settings extends Model
     // =========================================================================
 
     /**
-     * @var string Social Feed base url
+     * @var string Social Feed base url. Supports environment variables (e.g. '$JUICER_BASE_URL').
      */
     public $socialFeedBaseUrl = 'https://www.juicer.io';
 
@@ -40,7 +40,7 @@ class Settings extends Model
     ];
 
     /**
-     * @var string '/api/feeds/[company-name]'
+     * @var string '/api/feeds/[company-name]'. Supports environment variables (e.g. '$JUICER_API_PATH').
      */
     public $apiPath;
 

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -23,6 +23,13 @@ class Settings extends Model
     // =========================================================================
 
     /**
+     * @var string|null Complete feed URL (e.g. 'https://www.juicer.io/api/feeds/my-feed').
+     *                  When set, takes precedence over socialFeedBaseUrl + apiPath.
+     *                  Supports environment variables (e.g. '$JUICER_FEED').
+     */
+    public $feedUrl;
+
+    /**
      * @var string Social Feed base url. Supports environment variables (e.g. '$JUICER_BASE_URL').
      */
     public $socialFeedBaseUrl = 'https://www.juicer.io';
@@ -40,7 +47,7 @@ class Settings extends Model
     ];
 
     /**
-     * @var string '/api/feeds/[company-name]'. Supports environment variables (e.g. '$JUICER_FEED').
+     * @var string '/api/feeds/[company-name]'. Supports environment variables (e.g. '$JUICER_API_PATH').
      */
     public $apiPath;
 
@@ -58,7 +65,8 @@ class Settings extends Model
     public function rules(): array
     {
         return [
-            [['apiPath', 'numberOfFeeds'], 'required'],
+            ['numberOfFeeds', 'required'],
+            [['apiPath'], 'required', 'when' => fn($model) => !$model->feedUrl],
         ];
     }
 }

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -40,7 +40,7 @@ class Settings extends Model
     ];
 
     /**
-     * @var string '/api/feeds/[company-name]'. Supports environment variables (e.g. '$JUICER_API_PATH').
+     * @var string '/api/feeds/[company-name]'. Supports environment variables (e.g. '$JUICER_FEED').
      */
     public $apiPath;
 

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -17,12 +17,24 @@
 
 {% do view.registerAssetBundle("homm\\hommsocialfeed\\assetbundles\\settings\\SettingsAsset") %}
 
-{{ forms.textField({
+{{ forms.autosuggestField({
+    label: 'Social Feed Base URL'|t('hommsocialfeed'),
+    instructions: 'The base URL of the Juicer API. Supports environment variables.'|t('hommsocialfeed'),
+    id: 'socialFeedBaseUrl',
+    name: 'socialFeedBaseUrl',
+    value: settings['socialFeedBaseUrl'],
+    suggestEnvVars: true,
+    suggestAliases: true,
+    required: true,
+}) }}
+
+{{ forms.autosuggestField({
     label: 'Social Feed API path'|t('hommsocialfeed'),
-    instructions: 'Example: /api/feeds/artdecohotelmontana'|t('hommsocialfeed'),
+    instructions: 'Example: /api/feeds/artdecohotelmontana. Supports environment variables.'|t('hommsocialfeed'),
     id: 'apiPath',
     name: 'apiPath',
     value: settings['apiPath'],
+    suggestEnvVars: true,
     required: true,
 }) }}
 


### PR DESCRIPTION
Currently, apiPath and socialFeedBaseUrl are used as plain strings without resolving environment variable references, making it impossible to store sensitive or environment-specific values in .env files.

This PR adds two improvements:

Env variable resolution — both socialFeedBaseUrl and apiPath are now passed through craft\helpers\App::parseEnv(), so values like $JUICER_API_PATH are properly resolved.

New feedUrl setting — allows passing the complete feed URL as a single value (e.g. $JUICER_FEED), which takes precedence over socialFeedBaseUrl + apiPath. Useful when the full URL is stored in one environment variable.

Usage:


// config/hommsocialfeed.php
return [
    'feedUrl' => '$JUICER_FEED',
];

# .env
JUICER_FEED=https://www.juicer.io/api/feeds/my-company